### PR TITLE
Fix boot.ts imports

### DIFF
--- a/client/boot.ts
+++ b/client/boot.ts
@@ -1,5 +1,5 @@
 import 'core-js';
-import 'zone.js/dist/zone-microtask';
+import 'zone.js/dist/zone';
 
 import {bootstrap} from 'angular2/platform/browser';
 import {provide} from 'angular2/core';

--- a/client/boot.ts
+++ b/client/boot.ts
@@ -4,11 +4,11 @@ import 'zone.js/dist/zone-microtask';
 import {bootstrap} from 'angular2/platform/browser';
 import {provide} from 'angular2/core';
 import {HTTP_PROVIDERS} from 'angular2/http';
+import {ROUTER_PROVIDERS} from 'angular2/router';
 import {
-  ROUTER_PROVIDERS,
   Location,
   LocationStrategy,
-  HashLocationStrategy} from 'angular2/router';
+  HashLocationStrategy} from 'angular2/platform/common';
 import {App} from './src/app';
 
 bootstrap(App, [

--- a/spec-bundle.js
+++ b/spec-bundle.js
@@ -1,6 +1,6 @@
 require('core-js');
 
-require('zone.js/dist/zone-microtask.js');
+require('zone.js/dist/zone.js');
 // require('zone.js/dist/long-stack-trace-zone.js');
 require('zone.js/dist/jasmine-patch.js');
 


### PR DESCRIPTION
Location and other related providers have been moved from `router` to `platform/common` as detailed here:
- https://github.com/angular/angular/issues/8229

and here:
- https://github.com/angular/angular/pull/8230/files
